### PR TITLE
[MODEL] Add solref/solimp to link options (optional)

### DIFF
--- a/farms_core/model/options.py
+++ b/farms_core/model/options.py
@@ -242,6 +242,8 @@ class LinkOptions(Options):
             'drag_coefficients',
             [0, 0, 0, 0, 0, 0],
         )
+        self.solref = kwargs.pop('solref', None)
+        self.solimp = kwargs.pop('solimp', None)
         self.extras: dict = kwargs.pop('extras', {})
         if kwargs.pop('strict', True) and kwargs:
             raise Exception(f'Unknown kwargs: {kwargs}')


### PR DESCRIPTION
Allow solref/solimp to be defined as a property per link of morphology.links in animat file.
Use with [#32](https://github.com/farmsim/farms_mujoco/pull/32) in farms_mujoco